### PR TITLE
Add customer login and signup functionality

### DIFF
--- a/API_Documentation.md
+++ b/API_Documentation.md
@@ -37,26 +37,128 @@ This is a comprehensive milk delivery booking system API that supports both sing
 http://localhost:3000/api/v1
 ```
 
+### Authorization
+All API endpoints (except authentication endpoints) require a Bearer token in the Authorization header:
+```
+Authorization: Bearer <your_jwt_token>
+```
+
+**Authentication Flow:**
+1. For customers: Use `/customer_login` endpoint which validates against Customer model
+2. For admin/delivery_person: Use `/login` endpoint with role parameter
+3. Use the returned JWT token in the Authorization header for subsequent API calls
+4. For customer signup: Both User and Customer records are created automatically
+
 ### Authentication
 
 #### POST `/login`
-User login endpoint
+Login endpoint for admin and delivery_person users
 ```json
 {
-  "email": "admin@example.com",
+  "phone": "+919876543210",
+  "password": "password123",
+  "role": "admin"
+}
+```
+
+Response:
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9...",
+  "user": {
+    "id": 1,
+    "name": "Admin User",
+    "role": "admin",
+    "email": "admin@example.com",
+    "phone": "+919876543210"
+  }
+}
+```
+
+#### POST `/customer_login`
+Login endpoint specifically for customers (checks Customer model)
+```json
+{
+  "phone": "+919876543220",
   "password": "password123"
+}
+```
+
+Response:
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9...",
+  "user": {
+    "id": 2,
+    "name": "Customer User",
+    "role": "customer",
+    "email": "customer@example.com",
+    "phone": "+919876543220"
+  },
+  "customer": {
+    "id": 1,
+    "name": "Customer Name",
+    "address": "123 Main St, City",
+    "phone_number": "+919876543220",
+    "email": "customer@example.com",
+    "preferred_language": "en",
+    "delivery_time_preference": "morning",
+    "notification_method": "sms"
+  }
 }
 ```
 
 #### POST `/signup`
 User registration endpoint
+For customers (role: "customer"):
 ```json
 {
   "name": "Test Customer",
   "email": "customer@example.com",
   "phone": "+919876543220",
   "password": "password123",
-  "role": "customer"
+  "role": "customer",
+  "address": "123 Main St, City",
+  "latitude": 12.9716,
+  "longitude": 77.5946,
+  "phone_number": "+919876543220",
+  "preferred_language": "en",
+  "delivery_time_preference": "morning",
+  "notification_method": "sms"
+}
+```
+
+For admin/delivery_person:
+```json
+{
+  "name": "Admin User",
+  "email": "admin@example.com",
+  "phone": "+919876543210",
+  "password": "password123",
+  "role": "admin"
+}
+```
+
+Response (for customer):
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9...",
+  "user": {
+    "id": 2,
+    "name": "Test Customer",
+    "role": "customer",
+    "email": "customer@example.com",
+    "phone": "+919876543220"
+  },
+  "customer": {
+    "id": 1,
+    "name": "Test Customer",
+    "address": "123 Main St, City",
+    "phone_number": "+919876543220",
+    "email": "customer@example.com",
+    "latitude": 12.9716,
+    "longitude": 77.5946
+  }
 }
 ```
 
@@ -64,10 +166,12 @@ User registration endpoint
 
 #### GET `/categories`
 Get all product categories
+- **Headers:** `Authorization: Bearer <token>`
 - Returns: Array of categories with id, name, description, and color
 
 #### GET `/products`
 Get all products with optional filtering
+- **Headers:** `Authorization: Bearer <token>`
 - **Query Parameters:**
   - `category_id` - Filter by category
   - `available=true` - Only available products
@@ -83,6 +187,7 @@ Get products with low stock levels
 
 #### POST `/place_order`
 Place a single-day order
+- **Headers:** `Authorization: Bearer <token>`
 ```json
 {
   "customer_id": 1,
@@ -95,6 +200,7 @@ Place a single-day order
 
 #### GET `/orders`
 Get orders with optional filtering
+- **Headers:** `Authorization: Bearer <token>`
 - **Query Parameters:**
   - `customer_id` - Filter by customer
 - Returns: Array of orders with delivery details

--- a/Customer_Authentication_Implementation.md
+++ b/Customer_Authentication_Implementation.md
@@ -1,0 +1,110 @@
+# Customer Authentication Implementation Summary
+
+## Overview
+Implemented comprehensive login and signup functionality for customers with separate customer model handling as requested.
+
+## Changes Made
+
+### 1. Enhanced Authentication Controller (`app/controllers/api/v1/authentication_controller.rb`)
+
+#### Key Features Implemented:
+- **Role-based Authentication**: Different logic for customer vs admin/delivery_person users
+- **Customer-specific Login**: New `customer_login` method that validates against Customer model
+- **Automatic Customer Creation**: When role is "customer", both User and Customer records are created during signup
+- **Enhanced Token Response**: Returns both user and customer information for customers
+
+#### New Endpoints:
+- `POST /api/v1/customer_login` - Dedicated customer login endpoint
+- Enhanced `POST /api/v1/login` - Now handles role-based routing
+- Enhanced `POST /api/v1/signup` - Creates Customer record for customer signups
+
+### 2. Authentication Logic
+
+#### For Customers:
+- Login checks Customer model via User relationship
+- Signup creates both User and Customer records
+- Token includes both user_id and customer_id
+- Response includes customer-specific information
+
+#### For Admin/Delivery Person:
+- Login checks User model directly with role validation
+- Signup creates only User record
+- Token includes user_id only
+- Standard user information response
+
+### 3. API Routes Update (`config/routes.rb`)
+Added new route:
+```ruby
+post '/customer_login', to: 'authentication#customer_login'
+```
+
+### 4. Updated API Documentation (`API_Documentation.md`)
+
+#### New Documentation Includes:
+- Bearer token authorization requirements for all endpoints
+- Detailed authentication flow explanation
+- Separate examples for customer vs admin/delivery_person authentication
+- Request/response examples with proper headers
+- Customer signup with required customer fields
+
+## API Usage Examples
+
+### Customer Login
+```bash
+POST /api/v1/customer_login
+{
+  "phone": "+919876543220",
+  "password": "password123"
+}
+```
+
+### Customer Signup
+```bash
+POST /api/v1/signup
+{
+  "name": "John Customer",
+  "email": "john@example.com",
+  "phone": "+919876543220",
+  "password": "password123",
+  "role": "customer",
+  "address": "123 Main St, City",
+  "latitude": 12.9716,
+  "longitude": 77.5946,
+  "phone_number": "+919876543220",
+  "preferred_language": "en",
+  "delivery_time_preference": "morning",
+  "notification_method": "sms"
+}
+```
+
+### Admin/Delivery Person Login
+```bash
+POST /api/v1/login
+{
+  "phone": "+919876543210",
+  "password": "password123",
+  "role": "admin"
+}
+```
+
+## Security Features
+- JWT tokens with expiration (24 hours)
+- Role-based access control
+- Secure password authentication using bcrypt
+- Customer-specific validation through Customer model
+
+## Database Changes
+No schema changes required - utilizes existing User and Customer models with proper relationships.
+
+## Key Benefits
+1. **Separation of Concerns**: Customers are validated through Customer model, while admin/delivery staff use User model directly
+2. **Enhanced Security**: Role-based authentication prevents unauthorized access
+3. **Better UX**: Customer-specific endpoints return relevant customer information
+4. **Scalable**: Clean separation allows for future role-specific enhancements
+5. **Comprehensive**: All endpoints now properly documented with authorization requirements
+
+## Usage Notes
+- All API endpoints (except authentication) now require `Authorization: Bearer <token>` header
+- Customer login uses dedicated endpoint for better separation
+- Customer signup automatically creates both User and Customer records
+- Token contains customer_id for customers, enabling efficient customer-specific operations

--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -1,15 +1,60 @@
 module Api
   module V1
     class AuthenticationController < ApplicationController
-      skip_before_action :authenticate_request, only: [:login, :signup]
+      skip_before_action :authenticate_request, only: [:login, :signup, :customer_login]
 
       # POST /api/v1/login
       def login
-        @user = User.find_by(phone: params[:phone])
+        if params[:role] == 'customer'
+          customer_login
+        else
+          # For admin and delivery_person
+          @user = User.find_by(phone: params[:phone])
+          
+          if @user&.authenticate(params[:password]) && %w[admin delivery_person].include?(@user.role)
+            token = JsonWebToken.encode(user_id: @user.id)
+            render json: { 
+              token: token, 
+              user: { 
+                id: @user.id, 
+                name: @user.name, 
+                role: @user.role,
+                email: @user.email,
+                phone: @user.phone
+              } 
+            }, status: :ok
+          else
+            render json: { error: 'Invalid credentials' }, status: :unauthorized
+          end
+        end
+      end
+
+      # POST /api/v1/customer_login
+      def customer_login
+        @customer = Customer.joins(:user).find_by(users: { phone: params[:phone] })
         
-        if @user&.authenticate(params[:password])
-          token = JsonWebToken.encode(user_id: @user.id)
-          render json: { token: token, user: { id: @user.id, name: @user.name, role: @user.role } }, status: :ok
+        if @customer&.user&.authenticate(params[:password]) && @customer.user.customer?
+          token = JsonWebToken.encode(user_id: @customer.user.id, customer_id: @customer.id)
+          render json: { 
+            token: token, 
+            user: { 
+              id: @customer.user.id, 
+              name: @customer.user.name, 
+              role: @customer.user.role,
+              email: @customer.user.email,
+              phone: @customer.user.phone
+            },
+            customer: {
+              id: @customer.id,
+              name: @customer.name,
+              address: @customer.address,
+              phone_number: @customer.phone_number,
+              email: @customer.email,
+              preferred_language: @customer.preferred_language,
+              delivery_time_preference: @customer.delivery_time_preference,
+              notification_method: @customer.notification_method
+            }
+          }, status: :ok
         else
           render json: { error: 'Invalid credentials' }, status: :unauthorized
         end
@@ -20,8 +65,49 @@ module Api
         @user = User.new(user_params)
         
         if @user.save
-          token = JsonWebToken.encode(user_id: @user.id)
-          render json: { token: token, user: { id: @user.id, name: @user.name, role: @user.role } }, status: :created
+          # If role is customer, create customer record
+          if @user.customer?
+            @customer = Customer.new(customer_params.merge(user: @user))
+            
+            if @customer.save
+              token = JsonWebToken.encode(user_id: @user.id, customer_id: @customer.id)
+              render json: { 
+                token: token, 
+                user: { 
+                  id: @user.id, 
+                  name: @user.name, 
+                  role: @user.role,
+                  email: @user.email,
+                  phone: @user.phone
+                },
+                customer: {
+                  id: @customer.id,
+                  name: @customer.name,
+                  address: @customer.address,
+                  phone_number: @customer.phone_number,
+                  email: @customer.email,
+                  latitude: @customer.latitude,
+                  longitude: @customer.longitude
+                }
+              }, status: :created
+            else
+              @user.destroy # Rollback user creation if customer creation fails
+              render json: { errors: @customer.errors.full_messages }, status: :unprocessable_entity
+            end
+          else
+            # For admin and delivery_person roles
+            token = JsonWebToken.encode(user_id: @user.id)
+            render json: { 
+              token: token, 
+              user: { 
+                id: @user.id, 
+                name: @user.name, 
+                role: @user.role,
+                email: @user.email,
+                phone: @user.phone
+              } 
+            }, status: :created
+          end
         else
           render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
         end
@@ -31,6 +117,12 @@ module Api
 
       def user_params
         params.permit(:name, :email, :phone, :password, :role)
+      end
+
+      def customer_params
+        params.permit(:name, :address, :phone_number, :email, :latitude, :longitude, 
+                     :preferred_language, :delivery_time_preference, :notification_method, 
+                     :address_type, :address_landmark, :alt_phone_number)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       # Authentication routes
       post '/signup', to: 'authentication#signup'
       post '/login', to: 'authentication#login'
+      post '/customer_login', to: 'authentication#customer_login'
       
       # Categories routes
       resources :categories, only: [:index, :show, :create, :update, :destroy]


### PR DESCRIPTION
Implement customer-specific login and signup, separating authentication logic from other user roles.

This PR introduces a dedicated `/customer_login` endpoint and enhances the `/login` and `/signup` endpoints to handle role-based authentication. Customers now have their own authentication flow, including automatic `Customer` record creation during signup, while admin and delivery person roles continue to use the general login. API documentation has been updated to reflect these changes and enforce bearer token authorization.