### PR TITLE
Add bank details and qr code api

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,98 @@
+# Bank Details API
+
+## GET /api/v1/bank_details
+
+Returns the bank details and payment information for the business, including QR code for UPI payments.
+
+### Authentication
+Requires valid JWT token in the Authorization header:
+```
+Authorization: Bearer <jwt_token>
+```
+
+### Request
+```http
+GET /api/v1/bank_details
+Content-Type: application/json
+Authorization: Bearer <jwt_token>
+```
+
+### Response
+
+#### Success Response (200 OK)
+```json
+{
+  "bank_details": {
+    "business_name": "Atma Nirbhar Farm",
+    "address": "123 Farm Road, Rural Area, Karnataka",
+    "mobile": "+919876543210",
+    "email": "admin@atmanirbharfarm.com",
+    "gstin": "29AAAAA0000A1Z5",
+    "pan_number": "AAAAA0000A",
+    "account_holder_name": "Atma Nirbhar Farm",
+    "bank_name": "Canara Bank",
+    "account_number": "3194201000718",
+    "ifsc_code": "CNRB0003194",
+    "upi_id": "atmanirbharfarm@canara",
+    "terms_and_conditions": [
+      "Kindly make your monthly payment on or before the 10th of every month.",
+      "Please share the payment screenshot immediately after completing the transaction to confirm your payment."
+    ],
+    "qr_code_url": "https://your-domain.com/qr_codes/upi_qr_1.svg"
+  }
+}
+```
+
+#### Error Response (404 Not Found)
+```json
+{
+  "error": "Bank details not configured"
+}
+```
+
+#### Error Response (401 Unauthorized)
+```json
+{
+  "error": "Invalid or missing token"
+}
+```
+
+### Features
+- Returns complete business and banking information
+- Automatically generates UPI QR code if UPI ID is provided
+- QR code is saved as SVG format in `/public/qr_codes/` directory
+- Returns full URL to access the QR code image
+- Terms and conditions are formatted as an array of strings
+
+### QR Code Generation
+- QR codes are generated using the `rqrcode` gem
+- Saved as SVG files for scalability
+- Named with pattern: `upi_qr_{admin_setting_id}.svg`
+- Accessible via the returned `qr_code_url`
+
+### Usage Example
+
+```javascript
+// Example using fetch API
+fetch('/api/v1/bank_details', {
+  method: 'GET',
+  headers: {
+    'Authorization': 'Bearer ' + token,
+    'Content-Type': 'application/json'
+  }
+})
+.then(response => response.json())
+.then(data => {
+  console.log('Bank Details:', data.bank_details);
+  if (data.bank_details.qr_code_url) {
+    // Display QR code image
+    document.getElementById('qr-image').src = data.bank_details.qr_code_url;
+  }
+});
+```
+
+### Notes
+- Only one admin setting record is supported (uses `AdminSetting.first`)
+- QR code is regenerated each time the endpoint is called if UPI ID exists
+- All bank details are required fields except address, gstin, pan_number, and upi_id
+- Email format and UPI ID format are validated at the model level

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'pry'
 gem 'jwt', '~> 2.3'
 gem 'geocoder'
+gem 'rqrcode'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/app/controllers/admin_settings_controller.rb
+++ b/app/controllers/admin_settings_controller.rb
@@ -1,0 +1,93 @@
+class AdminSettingsController < ApplicationController
+  before_action :require_login
+  before_action :set_admin_setting, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @admin_setting = AdminSetting.first || AdminSetting.new
+    redirect_to @admin_setting if @admin_setting.persisted?
+  end
+
+  def show
+    generate_qr_code if @admin_setting.upi_id.present?
+  end
+
+  def new
+    @admin_setting = AdminSetting.new
+    set_default_values
+  end
+
+  def create
+    @admin_setting = AdminSetting.new(admin_setting_params)
+    
+    if @admin_setting.save
+      generate_qr_code if @admin_setting.upi_id.present?
+      redirect_to @admin_setting, notice: 'Admin settings were successfully created.'
+    else
+      render :new
+    end
+  end
+
+  def edit
+    # Set default brand name if empty
+    if @admin_setting.business_name.blank?
+      @admin_setting.business_name = current_user&.name || "Atma Nirbhar Farm"
+    end
+  end
+
+  def update
+    if @admin_setting.update(admin_setting_params)
+      generate_qr_code if @admin_setting.upi_id.present?
+      redirect_to @admin_setting, notice: 'Admin settings were successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @admin_setting.destroy
+    redirect_to admin_settings_path, notice: 'Admin settings were successfully deleted.'
+  end
+
+  private
+
+  def set_admin_setting
+    @admin_setting = AdminSetting.find(params[:id])
+  end
+
+  def admin_setting_params
+    params.require(:admin_setting).permit(:business_name, :address, :mobile, :email, :gstin, :pan_number,
+                                          :account_holder_name, :bank_name, :account_number, :ifsc_code,
+                                          :upi_id, :terms_and_conditions)
+  end
+
+  def set_default_values
+    @admin_setting.business_name = current_user&.name || "Atma Nirbhar Farm"
+    @admin_setting.account_holder_name = current_user&.name || "Atma Nirbhar Farm"
+    @admin_setting.bank_name = "Canara Bank"
+    @admin_setting.account_number = "3194201000718"
+    @admin_setting.ifsc_code = "CNRB0003194"
+    @admin_setting.terms_and_conditions = "Kindly make your monthly payment on or before the 10th of every month.\nPlease share the payment screenshot immediately after completing the transaction to confirm your payment."
+  end
+
+  def generate_qr_code
+    require 'rqrcode'
+    
+    qr = RQRCode::QRCode.new(@admin_setting.upi_id)
+    
+    # Generate SVG
+    svg = qr.as_svg(
+      color: "000",
+      shape_rendering: "crispEdges",
+      module_size: 6,
+      standalone: true
+    )
+    
+    # Save to storage
+    qr_code_path = Rails.root.join('public', 'qr_codes')
+    FileUtils.mkdir_p(qr_code_path) unless Dir.exist?(qr_code_path)
+    
+    File.write(Rails.root.join('public', 'qr_codes', "upi_qr_#{@admin_setting.id}.svg"), svg)
+    
+    @admin_setting.update(qr_code_path: "/qr_codes/upi_qr_#{@admin_setting.id}.svg")
+  end
+end

--- a/app/controllers/api/v1/bank_details_controller.rb
+++ b/app/controllers/api/v1/bank_details_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module V1
+    class BankDetailsController < ApplicationController
+      before_action :authenticate_request
+
+      # GET /api/v1/bank_details
+      def show
+        @admin_setting = AdminSetting.first
+        
+        if @admin_setting.nil?
+          render json: { error: 'Bank details not configured' }, status: :not_found
+          return
+        end
+
+        generate_qr_code if @admin_setting.upi_id.present?
+
+        bank_details = {
+          business_name: @admin_setting.business_name,
+          address: @admin_setting.address,
+          mobile: @admin_setting.mobile,
+          email: @admin_setting.email,
+          gstin: @admin_setting.gstin,
+          pan_number: @admin_setting.pan_number,
+          account_holder_name: @admin_setting.account_holder_name,
+          bank_name: @admin_setting.bank_name,
+          account_number: @admin_setting.account_number,
+          ifsc_code: @admin_setting.ifsc_code,
+          upi_id: @admin_setting.upi_id,
+          terms_and_conditions: @admin_setting.formatted_terms_and_conditions,
+          qr_code_url: @admin_setting.qr_code_path.present? ? request.base_url + @admin_setting.qr_code_path : nil
+        }
+
+        render json: { bank_details: bank_details }, status: :ok
+      end
+
+      private
+
+      def generate_qr_code
+        require 'rqrcode'
+        
+        qr = RQRCode::QRCode.new(@admin_setting.upi_id)
+        
+        # Generate SVG
+        svg = qr.as_svg(
+          color: "000",
+          shape_rendering: "crispEdges",
+          module_size: 6,
+          standalone: true
+        )
+        
+        # Save to storage
+        qr_code_path = Rails.root.join('public', 'qr_codes')
+        FileUtils.mkdir_p(qr_code_path) unless Dir.exist?(qr_code_path)
+        
+        File.write(Rails.root.join('public', 'qr_codes', "upi_qr_#{@admin_setting.id}.svg"), svg)
+        
+        @admin_setting.update(qr_code_path: "/qr_codes/upi_qr_#{@admin_setting.id}.svg")
+      end
+    end
+  end
+end

--- a/app/models/admin_setting.rb
+++ b/app/models/admin_setting.rb
@@ -1,0 +1,14 @@
+class AdminSetting < ApplicationRecord
+  validates :business_name, presence: true
+  validates :mobile, presence: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :account_holder_name, presence: true
+  validates :bank_name, presence: true
+  validates :account_number, presence: true
+  validates :ifsc_code, presence: true
+  validates :upi_id, format: { with: /\A[a-zA-Z0-9.\-_]+@[a-zA-Z0-9.\-_]+\z/, message: "must be a valid UPI ID" }, allow_blank: true
+
+  def formatted_terms_and_conditions
+    terms_and_conditions.split("\n").map(&:strip).reject(&:empty?)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,9 @@ Rails.application.routes.draw do
       # Delivery items routes (for individual item operations)
       resources :delivery_items, only: [:show, :update, :destroy]
       
+      # Bank details route
+      get '/bank_details', to: 'bank_details#show'
+      
       # Legacy delivery routes (keeping for backward compatibility)
       scope :deliveries do
         post '/start', to: 'deliveries#start'

--- a/db/migrate/20250724021247_create_admin_settings.rb
+++ b/db/migrate/20250724021247_create_admin_settings.rb
@@ -1,0 +1,25 @@
+class CreateAdminSettings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :admin_settings do |t|
+      t.string :business_name, null: false
+      t.text :address
+      t.string :mobile, null: false
+      t.string :email, null: false
+      t.string :gstin
+      t.string :pan_number
+      t.string :account_holder_name, null: false
+      t.string :bank_name, null: false
+      t.string :account_number, null: false
+      t.string :ifsc_code, null: false
+      t.string :upi_id
+      t.text :terms_and_conditions
+      t.string :qr_code_path
+
+      t.timestamps
+    end
+
+    # Add indexes for commonly queried fields
+    add_index :admin_settings, :email, unique: true
+    add_index :admin_settings, :mobile
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -212,4 +212,20 @@ assignment4 = DeliveryAssignment.create!(
   status: 'pending'
 )
 
+# Create default admin settings
+AdminSetting.create!(
+  business_name: 'Atma Nirbhar Farm',
+  address: '123 Farm Road, Rural Area, Karnataka',
+  mobile: '+919876543210',
+  email: 'admin@atmanirbharfarm.com',
+  gstin: '29AAAAA0000A1Z5',
+  pan_number: 'AAAAA0000A',
+  account_holder_name: 'Atma Nirbhar Farm',
+  bank_name: 'Canara Bank',
+  account_number: '3194201000718',
+  ifsc_code: 'CNRB0003194',
+  upi_id: 'atmanirbharfarm@canara',
+  terms_and_conditions: "Kindly make your monthly payment on or before the 10th of every month.\nPlease share the payment screenshot immediately after completing the transaction to confirm your payment."
+)
+
 puts "Seed data created successfully!"


### PR DESCRIPTION
Add `GET /api/v1/bank_details` endpoint to expose business bank details and UPI QR code.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1a6d6476-f0c8-44b1-a3c9-5327a95ec00d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1a6d6476-f0c8-44b1-a3c9-5327a95ec00d)