### PR TITLE
Fix invoice grouping and ordering error

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -39,10 +39,11 @@ module Api
       end
 
       def build_summary(relation)
-        counts_by_status = relation.group(:status).count
-        total_amount = relation.sum(:total_amount).to_f
+        relation_without_order = relation.except(:order)
+        counts_by_status = relation_without_order.group(:status).count
+        total_amount = relation_without_order.sum(:total_amount).to_f
         {
-          total_count: relation.count,
+          total_count: relation_without_order.count,
           total_amount: total_amount,
           pending_count: counts_by_status['pending'] || 0,
           paid_count: counts_by_status['paid'] || 0,


### PR DESCRIPTION
Remove `ORDER BY` from relations used for aggregations to fix `PG::GroupingError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-392286c2-4b2c-4df0-9dd7-208fbfe975ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-392286c2-4b2c-4df0-9dd7-208fbfe975ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

